### PR TITLE
Fix Tests Again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM python:2.7
 ENV PYTHONUNBUFFERED 1
-RUN apt-get update -qq && apt-get install -y python-mysqldb mysql-client
+RUN apt-get update -qq && apt-get install -y python3 python-mysqldb mysql-client
 RUN mkdir /app
 WORKDIR /app
 ADD requirements/ /app/requirements/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 -r requirements/requirements-dev.txt
 -r requirements/requirements-codestyle.txt
 -r requirements/requirements-test.txt
+-r requirements/requirements-common.txt

--- a/requirements/requirements-common.txt
+++ b/requirements/requirements-common.txt
@@ -1,0 +1,1 @@
+MySQL-python==1.2.5

--- a/requirements/requirements-common.txt
+++ b/requirements/requirements-common.txt
@@ -1,1 +1,1 @@
-MySQL-python==1.2.5
+PyMySQL==0.6.6

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,3 +1,2 @@
 django-debug-toolbar==1.2.2
 ipython==2.4.0
-MySQL-python==1.2.5

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,3 +1,4 @@
 tox==1.8.1
-pytest-django==2.8.0
+pytest-django==2.7.0
 pytest==2.6.4
+pytest-xdist

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,3 +1,4 @@
 tox==1.8.1
 pytest-django==2.7.0
 pytest==2.6.4
+MySQL-python==1.2.5

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,4 +1,3 @@
 tox==1.8.1
-pytest-django==2.7.0
+pytest-django==2.8.0
 pytest==2.6.4
-MySQL-python==1.2.5

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,4 +1,4 @@
 tox==1.8.1
-pytest-django==2.7.0
+pytest-django==2.8.0
 pytest==2.6.4
 pytest-xdist

--- a/tests/settings/__init__.py
+++ b/tests/settings/__init__.py
@@ -1,0 +1,2 @@
+import pymysql
+pymysql.install_as_MySQLdb()

--- a/tests/settings/test-sqlite.py
+++ b/tests/settings/test-sqlite.py
@@ -1,0 +1,14 @@
+# Test configuration for quick execution.
+#
+# This settings file will not work for tests against
+# Django 1.6, as it does not support Auto incrementing primary
+# keys in way required by django-name.
+from .base import *
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'TEST_NAME': ':memory:',
+    }
+}

--- a/tests/settings/test-sqlite.py
+++ b/tests/settings/test-sqlite.py
@@ -9,6 +9,6 @@ from .base import *
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'TEST_NAME': ':memory:',
+        'NAME': ':memory:',
     }
 }

--- a/tests/settings/test.py
+++ b/tests/settings/test.py
@@ -1,8 +1,12 @@
 from .base import *
 
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'TEST_NAME': ':memory:'
+        'ENGINE': 'django.db.backends.mysql',
+        'TEST_NAME': 'name-test',
+        'USER': 'root',
+        'PASSWORD': 'root',
+        'HOST': 'db',
     }
 }

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -7,7 +7,7 @@ try: import simplejson as json
 except ImportError: import json
 
 
-class NameCase(unittest.TestCase):
+class NameCase(TestCase):
 
     def setUp(self):
         Name(name='test person', name_type=0, begin='2012-01-12').save()
@@ -21,9 +21,6 @@ class NameCase(unittest.TestCase):
             'map/',
             'feed/',
         ]
-
-    def tearDown(self):
-        Name.objects.all().delete()
 
 @pytest.mark.django_db(transaction=True)
 class NameTestCase(NameCase):

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,82 +1,101 @@
-import unittest
-
 import pytest
-from name.models import Name, BaseTicketing
-from django.test import Client, TestCase
-try: import simplejson as json
-except ImportError: import json
+import json
+
+from name.models import Name
+from django.core.urlresolvers import reverse
 
 
-class NameCase(TestCase):
-
-    def setUp(self):
-        Name(name='test person', name_type=0, begin='2012-01-12').save()
-        Name(name='test organization', name_type=1, begin='2000-01-12').save()
-        Name(name='test event', name_type=2, begin='2500-01-12').save()
-        Name(name='test building', name_type=4, begin='2000-01-12').save()
-        self.c = Client()
-        self.routes_to_test = [
-            'about/',
-            'stats/',
-            'map/',
-            'feed/',
-        ]
-
-@pytest.mark.django_db(transaction=True)
-class NameTestCase(NameCase):
-
-    def test_response_codes(self):
-        for test_route in self.routes_to_test:
-            response = self.c.get('/name/%s' % test_route)
-            self.assertEqual(response.status_code, 200)
+@pytest.fixture
+def name_fixtures(db, scope="module"):
+    Name.objects.create(name='test person',
+                        name_type=0, begin='2012-01-12')
+    Name.objects.create(name='test organization',
+                        name_type=1, begin='2000-01-12')
+    Name.objects.create(name='test event',
+                        name_type=2, begin='2500-01-12')
+    Name.objects.create(name='test building',
+                        name_type=4, begin='2000-01-12')
 
 
-@pytest.mark.django_db(transaction=True)
-class NameSearchCase(NameCase):
+@pytest.mark.django_db
+class TestViews:
+    def test_response_codes(self, client, name_fixtures):
+        routes_to_test = [ 'about/', 'stats/', 'map/', 'feed/']
+        for test_route in routes_to_test:
+            response = client.get('/name/%s' % test_route)
+            assert response.status_code is 200
 
-    def test_json_returns_expected_results(self):
-        response = self.c.get('/name/search.json?q_type=Personal&q=person')
-        self.assertTrue(json.loads(response.content)[0]['name'] == 'test person')
-        self.assertEqual(response.status_code, 200)
 
-    def test_can_json_search_multiple_name_types(self):
-        response = self.c.get('/name/search.json?q_type=Personal,Organization&q=test')
+@pytest.mark.django_db
+class TestNameSearchCase:
+
+    def test_json_returns_expected_results(self, client, name_fixtures):
+        response = client.get('/name/search.json?q_type=Personal&q=person')
+
+        assert json.loads(response.content)[0]['name'] == 'test person'
+        assert response.status_code is 200
+
+    def test_can_json_search_multiple_name_types(self, client, name_fixtures):
+        response = client.get(
+            '/name/search.json?q_type=Personal,Organization&q=test')
         json_results = json.loads(response.content)
-        self.assertTrue(len(json_results) == 2)
-        self.assertEqual(response.status_code, 200)
 
-    def test_can_search_multiple_name_types(self):
-        response = self.c.get('/name/search/?q_type=Personal,Organization&q=test')
-        self.assertEqual(response.status_code, 200)
+        assert len(json_results) is 2
+        assert response.status_code is 200
 
-    def test_can_search(self):
-        response = self.c.get('/name/search/?q_type=Personal&q=test')
-        self.assertEqual(response.status_code, 200)
+    def test_can_search_multiple_name_types(self, client, name_fixtures):
+        response = client.get(
+            '/name/search/?q_type=Personal,Organization&q=test')
+
+        assert response.status_code is 200
+
+    def test_can_search(self, client, name_fixtures):
+        response = client.get('/name/search/?q_type=Personal&q=test')
+        assert response.status_code is 200
 
 
-@pytest.mark.django_db(transaction=True)
-class NameDetailCase(NameCase):
+@pytest.mark.django_db
+class TestNameDetailCase:
     """
-    This class is inteded to check that the intended html properties are showing correctly
+    This class is intended to check that the intended html properties
+    are showing correctly
     """
-    def test_itemprops(self):
-        # people get certain itemprops
-        response = self.c.get('/name/nm0000001/')
-        self.assertTrue('itemprop=\"name\"' in response.content)
-        self.assertTrue('itemprop=\'url\'' in response.content)
-        self.assertTrue('itemprop=\"birthDate\"' in response.content)
-        # buildings get others
-        response = self.c.get('/name/nm0000004/')
-        self.assertTrue('itemprop=\"name\"' in response.content)
-        self.assertTrue('itemprop=\'url\'' in response.content)
-        self.assertTrue('itemprop=\"erectedDate\"' in response.content)
-        # organizations get others still
-        response = self.c.get('/name/nm0000002/')
-        self.assertTrue('itemprop=\"name\"' in response.content)
-        self.assertTrue('itemprop=\'url\'' in response.content)
-        self.assertTrue('itemprop=\"foundingDate\"' in response.content)
-        # events get others still
-        response = self.c.get('/name/nm0000003/')
-        self.assertTrue('itemprop=\"name\"' in response.content)
-        self.assertTrue('itemprop=\'url\'' in response.content)
-        self.assertTrue('itemprop=\"startDate\"' in response.content)
+    def test_person_itemprops(self, client):
+        name = Name.objects.create(name='test person',
+                                   name_type=0, begin='2012-01-12')
+        response = client.get(
+            reverse('name_entry_detail', args=[name.name_id]))
+
+        assert 'itemprop=\"name\"' in response.content
+        assert 'itemprop=\'url\'' in response.content
+        assert 'itemprop=\"birthDate\"' in response.content
+
+    def test_building_itemprops(self, client):
+        name = Name.objects.create(name='test building',
+                                   name_type=4, begin='2000-01-12')
+        response = client.get(
+            reverse('name_entry_detail', args=[name.name_id]))
+
+        assert 'itemprop=\"name\"' in response.content
+        assert 'itemprop=\'url\'' in response.content
+        assert 'itemprop=\"erectedDate\"' in response.content
+
+    def test_organization_itemprops(self, client):
+        name = Name.objects.create(name='test organization',
+                                   name_type=1, begin='2000-01-12')
+        response = client.get(
+            reverse('name_entry_detail', args=[name.name_id]))
+
+        assert 'itemprop=\"name\"' in response.content
+        assert 'itemprop=\'url\'' in response.content
+        assert 'itemprop=\"foundingDate\"' in response.content
+
+    def test_event_itemprops(self, client):
+        name = Name.objects.create(name='test event',
+                                   name_type=2, begin='2500-01-12')
+        response = client.get(
+            reverse('name_entry_detail', args=[name.name_id]))
+
+        assert 'itemprop=\"name\"' in response.content
+        assert 'itemprop=\'url\'' in response.content
+        assert 'itemprop=\"startDate\"' in response.content

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,19 +1,19 @@
 import unittest
+
 import pytest
-from name.models import Name
-from django.test import Client
+from name.models import Name, BaseTicketing
+from django.test import Client, TestCase
 try: import simplejson as json
 except ImportError: import json
 
 
-@pytest.mark.django_db(transaction=True)
 class NameCase(unittest.TestCase):
 
     def setUp(self):
-        Name(name='test person', name_type=0, begin='2012-01-12', name_id='nm0000001').save()
-        Name(name='test organization', name_type=1, begin='2000-01-12', name_id="nm0000002").save()
-        Name(name='test event', name_type=2, begin='2500-01-12', name_id="nm0000003").save()
-        Name(name='test building', name_type=4, begin='2000-01-12', name_id="nm0000004").save()
+        Name(name='test person', name_type=0, begin='2012-01-12').save()
+        Name(name='test organization', name_type=1, begin='2000-01-12').save()
+        Name(name='test event', name_type=2, begin='2500-01-12').save()
+        Name(name='test building', name_type=4, begin='2000-01-12').save()
         self.c = Client()
         self.routes_to_test = [
             'about/',
@@ -22,8 +22,8 @@ class NameCase(unittest.TestCase):
             'feed/',
         ]
 
-    # def tearDown(self):
-    #     Name.objects.all().delete()
+    def tearDown(self):
+        Name.objects.all().delete()
 
 @pytest.mark.django_db(transaction=True)
 class NameTestCase(NameCase):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ DJANGO_SETTINGS_MODULE = tests.settings.test
 envlist =
     py27-flake8,
     ; {py27}-django14,
-    {py27,py34}-django{15,16,17,18beta},
+    {py27,py34}-django{16,17,18beta},
 
 [testenv]
 deps = 
@@ -17,7 +17,7 @@ deps =
     django18beta: https://www.djangoproject.com/download/1.8b1/tarball/
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-test.txt
-commands = ./runtests.py --fast
+commands = ./runtests.py --capture=no --fast
 
 [testenv:py27-flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ DJANGO_SETTINGS_MODULE = tests.settings.test
 [tox]
 envlist =
     py27-flake8,
-    ; {py27}-django14,
     {py27,py34}-django{16,17,18beta},
 
 [testenv]
@@ -17,7 +16,8 @@ deps =
     django18beta: https://www.djangoproject.com/download/1.8b1/tarball/
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-test.txt
-commands = ./runtests.py --capture=no --fast
+    -rrequirements/requirements-common.txt
+commands = ./runtests.py --fast
 
 [testenv:py27-flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --create-db
+addopts = --reuse-db
 DJANGO_SETTINGS_MODULE = tests.settings.test
 
 [tox]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [pytest]
 addopts = --reuse-db
 DJANGO_SETTINGS_MODULE = tests.settings.test
+django_find_project = false
 
 [tox]
 envlist =
@@ -14,6 +15,7 @@ deps =
     django16: Django==1.6.8
     django17: Django==1.7.1
     django18beta: https://www.djangoproject.com/download/1.8b1/tarball/
+    -e. 
     -rrequirements/requirements-base.txt
     -rrequirements/requirements-test.txt
     -rrequirements/requirements-common.txt


### PR DESCRIPTION
Will resolve #9 

This is still a WIP. Opening this PR request to track changes and allow for comments.

In addition to removing the dependency on explicitly setting the `name_id` field, this will also transition the test from using the `django.test.TestCase` to use [py.test](http://pytest.org)
