### PR TITLE
Prepare setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.swo
 *.egg-info
+dist/
 .tox
 db.sqlite3
 tests/__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ env:
         - TOX_ENV=py27-django16
         - TOX_ENV=py27-django17
         - TOX_ENV=py27-django18
+        - TOX_ENV=py27-djangomaster
         - TOX_ENV=flake8
         - TOX_ENV=docs
+    allow_failures:
+        - TOX_ENV=py27-djangomaster
 install:
     - pip install tox
 before_script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include *.txt *.md
 recursive-include name/templates * 
+recursive-include name/static * 

--- a/name/__init__.py
+++ b/name/__init__.py
@@ -1,1 +1,2 @@
 __title__ = "Django Name"
+__version__ = 'pre-release'

--- a/name/__init__.py
+++ b/name/__init__.py
@@ -1,2 +1,2 @@
-__title__ = "Django Name"
+__title__ = 'Django Name'
 __version__ = 'pre-release'

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,9 +1,5 @@
 # Packages that are required by the app.
-
-# Packages from PyPI.
 python-dateutil==2.4.2
 markdown2==2.3.0
 djangorestframework>=3.1
-
-# Packages from Github.
-git+git://github.com/unt-libraries/pynaco@0.1.0
+pynaco==0.1.0

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,7 +1,7 @@
 # Packages that are required by the app.
 
 # Packages from PyPI.
-dateutils==0.6.6
+python-dateutil==2.4.2
 markdown2==2.3.0
 djangorestframework>=3.1
 

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,45 @@
-
 #! /usr/bin/env python
 import os
+import re
 from setuptools import setup, find_packages
 
-# with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
-#     README = readme.read()
+version = ''
+with open('name/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
 
+readme = ''
+with open(os.path.join(os.path.dirname(__file__), 'README.md')) as fd:
+    readme = fd.read()
 
-# allow setup.py to be run from any path
-os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+install_requires = [
+    'python-dateutil',
+    'markdown2',
+    'djangorestframework >= 3.1',
+    'pynaco == 0.1.0'
+]
 
 setup(
-    name="django-name",
-    version="pre-release",
+    name='django-name',
+    version=version,
     packages=find_packages(),
     include_package_data=True,
-
-    license="BSD",
-    description="Name Authority App for Django.",
-    # long_description=README,
-    keywords="django name citation",
-    author="University of North Texas Libraries",
-    # cmdclass={'test': PyTest},
-    url="https://github.com/unt-libraries/django-name",
+    license='BSD',
+    description='Name Authority App for Django.',
+    long_description=readme,
+    keywords='django name citation',
+    author='University of North Texas Libraries',
+    author_email='mark.phillips@unt.edu',
+    url='https://github.com/unt-libraries/django-name',
+    zip_safe=False,
+    install_requires=install_requires,
     classifiers=[
-        "Environment :: Web Environment",
-        "Framework :: Django",
-        "Intended Audience :: System Administrators",
-        "Intended Audience :: End Users/Desktop",
-        "License :: OSI Approved :: BSD License",
-        "Natural Language :: English",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application :: User Management"
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Intended Audience :: End Users/Desktop',
+        'Natural Language :: English',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Application :: User Management'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ django_find_project = false
 
 [tox]
 envlist =
-    flake8,
     py27-django{16,17,18},
+    flake8,
     docs
 
 [testenv]
@@ -15,7 +15,6 @@ deps =
     django16: Django==1.6
     django17: Django==1.7
     django18: Django==1.8
-    -rrequirements/requirements-base.txt
     -rrequirements/requirements-test.txt
     -rrequirements/requirements-common.txt
 commands = ./runtests.py {posargs} --nolint

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,17 @@ django_find_project = false
 
 [tox]
 envlist =
-    py27-django{16,17,18},
+    py27-django{16,17,18,master},
     flake8,
     docs
 
 [testenv]
 passenv = DB_*
-deps = 
+deps =
     django16: Django==1.6
     django17: Django==1.7
     django18: Django==1.8
+    djangomaster: https://github.com/django/django/archive/master.tar.gz
     -rrequirements/requirements-test.txt
     -rrequirements/requirements-common.txt
 commands = ./runtests.py {posargs} --nolint


### PR DESCRIPTION
Fixes #48 

What is included:
- Remove `dateutil` in favor of `python-dateutil`
  - The`dateutil` package appears to have been abandoned after 0.6. `python-dateutil` provides the same thing but is actively maintained. We are only using this for the `relativedelta` function anyway.
- Set the `author_email` to mark.phillips@unt.edu
- Get the pynaco package via pypi.
- Other minor cleanups to setup.py
- Adds a testenv for the tip of the Django master
