### PR TITLE
Namespaced URLs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,5 +35,5 @@ Installation
 
     urlpatterns = [
         ...
-        url(r'^name/', include('name.urls'))
+        url(r'^name/', include('name.urls', namespace='name'))
     ]

--- a/name/api/serializers.py
+++ b/name/api/serializers.py
@@ -78,7 +78,7 @@ class NameSerializer(serializers.ModelSerializer):
         begin_date -> name.begin
         end_date -> name.end
 
-    The identifier field is the absolute url to the name_entry_detail
+    The identifier field is the absolute url to the name detail
     page for the model instance.
     """
     authoritative_name = serializers.CharField(source='name')
@@ -89,7 +89,7 @@ class NameSerializer(serializers.ModelSerializer):
     notes = NoteSerializer(many=True, source='note_set')
     variants = VariantSerializer(many=True, source='variant_set')
     identifier = serializers.HyperlinkedIdentityField(
-        view_name='name_entry_detail', lookup_field='name_id')
+        view_name='name:detail', lookup_field='name_id')
 
     class Meta:
         model = models.Name
@@ -115,14 +115,14 @@ class NameSearchSerializer(serializers.ModelSerializer):
         type -> name.get_name_type_label()
         label -> Formats name.name and name.disambiguation.
 
-    The URL field is the absolute url to the name_entry_detail page for
+    The URL field is the absolute url to the name detail page for
     the model instance.
     """
     begin_date = serializers.CharField(source='begin')
     type = serializers.SerializerMethodField()
     label = serializers.SerializerMethodField()
     URL = serializers.HyperlinkedIdentityField(
-        view_name='name_entry_detail', lookup_field='name_id')
+        view_name='name:detail', lookup_field='name_id')
 
     class Meta:
         model = models.Name

--- a/name/api/views.py
+++ b/name/api/views.py
@@ -32,7 +32,7 @@ def stats_json(request):
 
 
 @jsonp
-def get_names(request):
+def search_json(request):
     """Gets the JSON encoded version of the Names matching
     the query parameters.
 
@@ -56,7 +56,7 @@ def get_names(request):
     return response
 
 
-def map_json(request):
+def locations_json(request):
     """Presents the Locations and related Names serialized into JSON."""
     if request.is_ajax():
         locations = Location.objects.filter(status=0)

--- a/name/feeds.py
+++ b/name/feeds.py
@@ -34,7 +34,7 @@ class NameAtomFeedType(Atom1Feed):
 class NameAtomFeed(Feed):
     """Atom Feed for Name objects."""
     feed_type = NameAtomFeedType
-    link = reverse_lazy("name_feed")
+    link = reverse_lazy("name:feed")
     title = "Name App"
     subtitle = "New Name Records"
 

--- a/name/models.py
+++ b/name/models.py
@@ -374,7 +374,7 @@ class Name(models.Model):
 
     def get_absolute_url(self):
         """Get the absolute url to the Name detail page."""
-        return reverse('name_entry_detail', args=[self.name_id])
+        return reverse('name:detail', args=[self.name_id])
 
     def get_schema_url(self):
         """Get the appropriate schema url based on the name type."""

--- a/name/templates/name/_navbar.html
+++ b/name/templates/name/_navbar.html
@@ -7,7 +7,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{% url "name_landing" %}">Name App</a>
+          <a class="navbar-brand" href="{% url "name:landing" %}">Name App</a>
         </div>
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -15,14 +15,14 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown"> Menu <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a href="{% url "name_stats" %}">Statistics</a></li>
-                        <li><a href="{% url "name_map" %}">Map</a></li>
+                        <li><a href="{% url "name:stats" %}">Statistics</a></li>
+                        <li><a href="{% url "name:map" %}">Map</a></li>
                     </ul>
                 </li>
-                <li><a href="{% url "name_about" %}">About</a></li>
-                <li><a href="{% url "name_feed" %}"><span class="fa fa-rss"></span></a></li>
+                <li><a href="{% url "name:about" %}">About</a></li>
+                <li><a href="{% url "name:feed" %}"><span class="fa fa-rss"></span></a></li>
             </ul>
-            <form class="navbar-form navbar-right" id="search" action="{% url "name_search" %}">
+            <form class="navbar-form navbar-right" id="search" action="{% url "name:search" %}">
                 <div class="form-group">
                     <select class="form-control" name="q_type" id="q_type">
                         {# Show current searched type as the default selection, if it exists #}
@@ -35,7 +35,7 @@
                         {% endfor %}
                     </select>
                     <input class="form-control" type="text" name="q" id="names" value="{{ q }}">
-                    <input type="hidden" value="{% url "name_names" %}" id="autocomplete">
+                    <input type="hidden" value="{% url "name:search-json" %}" id="autocomplete">
                     <button class="btn btn-default" type="submit">Submit</button>
                 </div>
             </form>

--- a/name/templates/name/about.html
+++ b/name/templates/name/about.html
@@ -9,7 +9,7 @@
             {% include "name/introduction.html" %}
 
             <h3>Two search modes are available.</h3>
-            <p>Notice there are two modes of searching. The first mode is a traditional search which takes a query and a type, filtering records containing your query in either the authorized name field or the variant field. The second search method is more of an existence lookup of the authorized name. The user should request <code>{% absolute_url "name_label" "name_string_here" %}</code>. The API will then either return a 302 Found and redirect to the matching record, or a 404 Not Found.  This page will first address the 'traditional' search API, then the label API.</p>
+            <p>Notice there are two modes of searching. The first mode is a traditional search which takes a query and a type, filtering records containing your query in either the authorized name field or the variant field. The second search method is more of an existence lookup of the authorized name. The user should request <code>{% absolute_url "name:label" "name_string_here" %}</code>. The API will then either return a 302 Found and redirect to the matching record, or a 404 Not Found.  This page will first address the 'traditional' search API, then the label API.</p>
 
             <h3>Search API</h3>
             <p>Let's dive right in! The following are various search examples using <a target="_blank" href="http://curl.haxx.se/docs/">curl</a>:</p>
@@ -17,70 +17,70 @@
                 <!--BEGIN CODE MARKUP-->
             <div>
                 <pre>
-    $ curl "{% absolute_url "name_names" %}?q=joey+liechty"
+    $ curl "{% absolute_url "name:search-json" %}?q=joey+liechty"
     [
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0051457" %}",
+            "URL": "{% absolute_url "name:detail" "nm0051457" %}",
             "id": "nm0051457",
             "name": "joey liechty",
             "type": "Personal"
         }
     ]
 
-    $ curl "{% absolute_url "name_names" %}?q=abc&amp;q_type=Organization&amp;callback=foo"
+    $ curl "{% absolute_url "name:search-json" %}?q=abc&amp;q_type=Organization&amp;callback=foo"
     foo([
         {
-            "URL": "{% url "name_entry_detail" "nm0000063" %}",
+            "URL": "{% url "name:detail" "nm0000063" %}",
             "id": "nm0000063",
             "name": "ABC Shop",
             "type": "Organization"
         }
     ])
 
-    $ curl "{% absolute_url "name_names" %}?q_type=Software"
+    $ curl "{% absolute_url "name:search-json" %}?q_type=Software"
     [
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0051455" %}",
+            "URL": "{% absolute_url "name:detail" "nm0051455" %}",
             "id": "nm0051455",
             "name": "Watson",
             "type": "Software"
         },
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0012345" %}",
+            "URL": "{% absolute_url "name:detail" "nm0012345" %}",
             "id": "nm0012345",
             "name": "Software Foo",
             "type": "Software"
         },
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0043212" %}",
+            "URL": "{% absolute_url "name:detail" "nm0043212" %}",
             "id": "nm0043212",
             "name": "123 SoftCom",
             "type": "Software"
         }
     ]
 
-    $ curl "{% absolute_url "name_names" %}?q_type=Software,Organization"
+    $ curl "{% absolute_url "name:search-json" %}?q_type=Software,Organization"
     [
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0051455" %}",
+            "URL": "{% absolute_url "name:detail" "nm0051455" %}",
             "id": "nm0051455",
             "name": "Watson",
             "type": "Software"
         },
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0012345" %}",
+            "URL": "{% absolute_url "name:detail" "nm0012345" %}",
             "id": "nm0012345",
             "name": "Software Foo",
             "type": "Software"
         },
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0043212" %}",
+            "URL": "{% absolute_url "name:detail" "nm0043212" %}",
             "id": "nm0043212",
             "name": "123 SoftCom",
             "type": "Software"
         },
         {
-            "URL": "{% absolute_url "name_entry_detail" "nm0000063" %}",
+            "URL": "{% absolute_url "name:detail" "nm0000063" %}",
             "id": "nm0000063",
             "name": "ABC Shop",
             "type": "Organization"
@@ -119,15 +119,15 @@
             <h3>Label API</h3>
             <p>The second method of searching is with the label API. The label API is essentially a quick way to determine if an authorized name exists in the Name App. The only two responses to this API are a 404 Not Found or a 302 Redirect.</p>
             <pre>
-    $ curl "{% absolute_url "name_label" "joey-not-here" %}"
+    $ curl "{% absolute_url "name:label" "joey-not-here" %}"
     No matching term found - authoritative, or variant - for "joey-not-here"
 
-    $ curl -I "{% absolute_url "name_label" "thisrecordisforsureinthedatabase" %}"
+    $ curl -I "{% absolute_url "name:label" "thisrecordisforsureinthedatabase" %}"
     HTTP/1.0 302 FOUND
     Date: Mon, 25 Feb 2013 22:33:19 GMT
     Server: WSGIServer/0.1 Python/2.7.3
     Content-Type: text/html; charset=utf-8
-    Location: {% absolute_url "name_entry_detail" "nm0000085" %}
+    Location: {% absolute_url "name:detail" "nm0000085" %}
             </pre>
 
             <h3>Label Return Codes</h3>

--- a/name/templates/name/base.html
+++ b/name/templates/name/base.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>{% block title %}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="search" type="application/opensearchdescription+xml" title="Name App Search" href="{% url 'name_opensearch' %}">
+    <link rel="search" type="application/opensearchdescription+xml" title="Name App Search" href="{% url "name:opensearch" %}">
     <link rel="icon" type="image/png" href="{% static "name/img/favicon.png" %}">
 
     <link rel="stylesheet" href="{% static 'name/css/name.css' %}">

--- a/name/templates/name/landing.html
+++ b/name/templates/name/landing.html
@@ -4,7 +4,7 @@
 {% load name_extras %}
 
 {%  block head-extra %}
-    <link rel="canonical" href="{% absolute_url "name_landing" %}">
+    <link rel="canonical" href="{% absolute_url "name:landing" %}">
 {% endblock head-extra %}
 
 {% block content %}
@@ -24,7 +24,7 @@
                     <tr>
                         <th>Personal Names:</th>
                         <td>
-                            <a href="{% url "name_search" %}?q_type=Personal&amp;q=">{{ counts.personal|intcomma }}</a>
+                            <a href="{% url "name:search" %}?q_type=Personal&amp;q=">{{ counts.personal|intcomma }}</a>
                         </td>
                     </tr>
                 {% endif %}
@@ -32,7 +32,7 @@
                     <tr>
                         <th>Organization Names:</th>
                         <td>
-                            <a href="{% url "name_search" %}?q_type=Organization&amp;q">{{ counts.organization|intcomma }}</a>
+                            <a href="{% url "name:search" %}?q_type=Organization&amp;q">{{ counts.organization|intcomma }}</a>
                         </td>
                     </tr>
                 {% endif %}
@@ -40,7 +40,7 @@
                     <tr>
                         <th>Event Names:</th>
                         <td>
-                            <a href="{% url "name_search" %}?q_type=Event&amp;q=">{{ counts.event|intcomma }}</a>
+                            <a href="{% url "name:search" %}?q_type=Event&amp;q=">{{ counts.event|intcomma }}</a>
                         </td>
                     </tr>
                 {% endif %}
@@ -48,7 +48,7 @@
                     <tr>
                         <th>Software Names:</th>
                         <td>
-                            <a href="{% url "name_search" %}?q_type=Software&amp;q=">{{ counts.software|intcomma }}</a>
+                            <a href="{% url "name:search" %}?q_type=Software&amp;q=">{{ counts.software|intcomma }}</a>
                         </td>
                     </tr>
                 {% endif %}
@@ -56,7 +56,7 @@
                     <tr>
                         <th>Building Names:</th>
                         <td>
-                            <a href="{% url "name_search" %}?q_type=Building&amp;q=">{{ counts.building|intcomma }}</a>
+                            <a href="{% url "name:search" %}?q_type=Building&amp;q=">{{ counts.building|intcomma }}</a>
                         </td>
                     </tr>
                 {% endif %}

--- a/name/templates/name/map.html
+++ b/name/templates/name/map.html
@@ -15,7 +15,7 @@
 {% block content %}
     <div class="row">
         <div class="col-sm-12">
-            <form name="map" action="{% url "name_map_json" %}">
+            <form name="map" action="{% url "name:locations-json" %}">
                 <span id="attribution" class="hidden">&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors</span>
             </form>
             <div id="map" style="width: 100%; height: 800px"></div>

--- a/name/templates/name/name.mads.xml
+++ b/name/templates/name/name.mads.xml
@@ -29,7 +29,7 @@
         <recordInfo>
             <recordCreationDate>{{ name.date_created|date:"Y-m-d" }}T{{ name.date_created|time:"H:i:s"}}</recordCreationDate>
             <recordChangeDate>{{ name.last_modified|date:"Y-m-d" }}T{{ name.last_modified|time:"H:i:s"}}</recordChangeDate>
-            <recordIdentifier>{% absolute_url "name_entry_detail" name.name_id %}</recordIdentifier>
+            <recordIdentifier>{% absolute_url "name:detail" name.name_id %}</recordIdentifier>
         </recordInfo>
         {% if name.note_set.exists %}
             {% for note in name.note_set.public_notes %}
@@ -41,6 +41,6 @@
                 <url displayLabel="{{ identifier.type.label }}">{{ identifier.value }}</url>
             {% endfor %}
         {% endif %}
-        <identifier type="URL">{% absolute_url "name_entry_detail" name.name_id %}</identifier>
+        <identifier type="URL">{% absolute_url "name:detail" name.name_id %}</identifier>
     </mads>
 {% endspaceless %}

--- a/name/templates/name/name_detail.html
+++ b/name/templates/name/name_detail.html
@@ -5,9 +5,9 @@
 {% block title %}{{ name.name }}{% endblock %}
 
 {% block head-extra %}
-    <link rel="canonical" href="{% absolute_url "name_entry_detail" name %}">
-    <link rel="alternate" type="application/xml" href="{% url "name_mads_serialize" name %}">
-    <link rel="alternate" type="application/json" href="{% url "name_json" name %}">
+    <link rel="canonical" href="{% absolute_url "name:detail" name %}">
+    <link rel="alternate" type="application/xml" href="{% url "name:mads-serialize" name %}">
+    <link rel="alternate" type="application/json" href="{% url "name:detail-json" name %}">
 {% endblock head-extra %}
 
 {% block content %}
@@ -201,7 +201,7 @@
 
     <h3>Alternate Formats</h3>
     <div>
-        <a class="btn btn-default" href="{% url "name_mads_serialize" name.name_id %}">MADS/XML</a>
-        <a class="btn btn-default" href="{% url "name_json" name.name_id %}">JSON</a>
+        <a class="btn btn-default" href="{% url "name:mads-serialize" name.name_id %}">MADS/XML</a>
+        <a class="btn btn-default" href="{% url "name:detail-json" name.name_id %}">JSON</a>
     </div>
 {% endblock content %}

--- a/name/templates/name/search.html
+++ b/name/templates/name/search.html
@@ -8,7 +8,7 @@
             <div class="col-sm-12">
                 <div class="text-center">
                     <h3>Search the Name App</h3>
-                    <form class="form form-inline" action="{% url "name_search" %}">
+                    <form class="form form-inline" action="{% url "name:search" %}">
                         <select class="form-control" name="q_type" id="large_q_type">
                             {% for k, v in name_types.items %}
                                 {% if request.GET.q_type == v %}
@@ -67,7 +67,7 @@
                             {% if entry.is_active and entry.merged_with == None %}
                                 <tr>
                                     <td>
-                                        <a href='{% url "name_entry_detail" entry %}'>{{ entry.name }}</a>
+                                        <a href='{% url "name:detail" entry %}'>{{ entry.name }}</a>
 
                                         {# If disambiguation exists, show as small print #}
                                         {% if entry.disambiguation %}

--- a/name/templates/name/stats.html
+++ b/name/templates/name/stats.html
@@ -19,7 +19,7 @@
     <div class="row">
         <div class="col-sm-12">
             <div class="text-center" id="dashboard">
-                <form action="{% url "name_stats_json" %}"></form>
+                <form action="{% url "name:stats-json" %}"></form>
                 <div class="btn-group">
                     <button class="btn btn-primary chart-nav" id="b0" data-chart-id="0">Names Created per Month</button>
                     <button class="btn btn-primary chart-nav" id="b1" data-chart-id="1">Running Created Names Total</button>

--- a/name/urls.py
+++ b/name/urls.py
@@ -1,33 +1,26 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib import admin
-from name import views, feeds
+
+from . import views, feeds
+from .api import views as api
 
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    url(r'stats.json/$', 'name.api.views.stats_json', name='stats-json'),
-    url(r'stats/$', 'name.views.stats', name='stats'),
-    url(r'label/(?P<name_value>.*)$', 'name.views.label', name='label'),
+urlpatterns = [
+    url(r'stats.json/$', api.stats_json, name='stats-json'),
+    url(r'stats/$', views.stats, name='stats'),
+    url(r'label/(?P<name_value>.*)$', views.label, name='label'),
     url(r'feed/$', feeds.NameAtomFeed(), name='feed'),
-    url(r'map/$', 'name.views.map', name='map'),
-    url(r'locations.json/$', 'name.api.views.locations_json', name='locations-json'),
-    url(r'^$', 'name.views.landing', name='landing'),
-    url(r'export/$', 'name.views.export', name='export'),
+    url(r'map/$', views.map, name='map'),
+    url(r'locations.json/$', api.locations_json, name='locations-json'),
+    url(r'^$', views.landing, name='landing'),
+    url(r'export/$', views.export, name='export'),
     url(r'search/$', views.SearchView.as_view(), name='search'),
-    url(r'search.json$', 'name.api.views.search_json', name="search-json"),
-    url(r'about/$', 'name.views.about', name='about'),
-    url(r'(?P<name_id>.*).json$', 'name.api.views.name_json', name='detail-json'),
-    url(r'opensearch.xml$', 'name.views.opensearch', name='opensearch'),
-    url(
-        r'(?P<name_id>.*).mads.xml$',
-        'name.views.mads_serialize',
-        name='mads-serialize'
-    ),
-    url(
-        r'(?P<name_id>[^/]+)/',
-        'name.views.detail',
-        name='detail'
-    ),
-)
+    url(r'search.json$', api.search_json, name="search-json"),
+    url(r'about/$', views.about, name='about'),
+    url(r'opensearch.xml$', views.opensearch, name='opensearch'),
+    url(r'(?P<name_id>.*).json$', api.name_json, name='detail-json'),
+    url(r'(?P<name_id>.*).mads.xml$', views.mads_serialize, name='mads-serialize'),
+    url(r'(?P<name_id>[^/]+)/', views.detail, name='detail')
+]

--- a/name/urls.py
+++ b/name/urls.py
@@ -7,28 +7,27 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'stats.json/$', 'name.api.views.stats_json', name='name_stats_json'),
-    url(r'stats/$', 'name.views.stats', name='name_stats'),
-    url(r'label/(?P<name_value>.*)$', 'name.views.label', name='name_label'),
-    url(r'feed/$', feeds.NameAtomFeed(), name='name_feed'),
-    url(r'label/(?P<name_value>.*)$', 'name.views.label', name='name_label'),
-    url(r'map/$', 'name.views.map', name='name_map'),
-    url(r'map.json/$', 'name.api.views.map_json', name='name_map_json'),
-    url(r'^$', 'name.views.landing', name='name_landing'),
-    url(r'export/$', 'name.views.export', name='name_export'),
-    url(r'search/$', views.SearchView.as_view(), name='name_search'),
-    url(r'search.json$', 'name.api.views.get_names', name="name_names"),
-    url(r'about/$', 'name.views.about', name='name_about'),
-    url(r'(?P<name_id>.*).json$', 'name.api.views.name_json', name='name_json'),
-    url(r'opensearch.xml$', 'name.views.opensearch', name='name_opensearch'),
+    url(r'stats.json/$', 'name.api.views.stats_json', name='stats-json'),
+    url(r'stats/$', 'name.views.stats', name='stats'),
+    url(r'label/(?P<name_value>.*)$', 'name.views.label', name='label'),
+    url(r'feed/$', feeds.NameAtomFeed(), name='feed'),
+    url(r'map/$', 'name.views.map', name='map'),
+    url(r'locations.json/$', 'name.api.views.locations_json', name='locations-json'),
+    url(r'^$', 'name.views.landing', name='landing'),
+    url(r'export/$', 'name.views.export', name='export'),
+    url(r'search/$', views.SearchView.as_view(), name='search'),
+    url(r'search.json$', 'name.api.views.search_json', name="search-json"),
+    url(r'about/$', 'name.views.about', name='about'),
+    url(r'(?P<name_id>.*).json$', 'name.api.views.name_json', name='detail-json'),
+    url(r'opensearch.xml$', 'name.views.opensearch', name='opensearch'),
     url(
         r'(?P<name_id>.*).mads.xml$',
         'name.views.mads_serialize',
-        name='name_mads_serialize'
+        name='mads-serialize'
     ),
     url(
         r'(?P<name_id>[^/]+)/',
-        'name.views.entry_detail',
-        name='name_entry_detail'
+        'name.views.detail',
+        name='detail'
     ),
 )

--- a/name/urls.py
+++ b/name/urls.py
@@ -8,18 +8,18 @@ from .api import views as api
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'stats.json/$', api.stats_json, name='stats-json'),
-    url(r'stats/$', views.stats, name='stats'),
-    url(r'label/(?P<name_value>.*)$', views.label, name='label'),
-    url(r'feed/$', feeds.NameAtomFeed(), name='feed'),
-    url(r'map/$', views.map, name='map'),
-    url(r'locations.json/$', api.locations_json, name='locations-json'),
     url(r'^$', views.landing, name='landing'),
+    url(r'about/$', views.about, name='about'),
     url(r'export/$', views.export, name='export'),
+    url(r'feed/$', feeds.NameAtomFeed(), name='feed'),
+    url(r'label/(?P<name_value>.*)$', views.label, name='label'),
+    url(r'locations.json/$', api.locations_json, name='locations-json'),
+    url(r'map/$', views.locations, name='map'),
+    url(r'opensearch.xml$', views.opensearch, name='opensearch'),
     url(r'search/$', views.SearchView.as_view(), name='search'),
     url(r'search.json$', api.search_json, name="search-json"),
-    url(r'about/$', views.about, name='about'),
-    url(r'opensearch.xml$', views.opensearch, name='opensearch'),
+    url(r'stats.json/$', api.stats_json, name='stats-json'),
+    url(r'stats/$', views.stats, name='stats'),
     url(r'(?P<name_id>.*).json$', api.name_json, name='detail-json'),
     url(r'(?P<name_id>.*).mads.xml$', views.mads_serialize, name='mads-serialize'),
     url(r'(?P<name_id>[^/]+)/', views.detail, name='detail')

--- a/name/views.py
+++ b/name/views.py
@@ -15,7 +15,7 @@ def label(request, name_value):
     """Find a name by label.
 
     If the label matches a single name, users are redirected
-    to the name_entry_detail page. Otherwise, if the label
+    to the name detail page. Otherwise, if the label
     does not exist, or the specified label matches multiple Name
     objects, a status code 404 is returned.
     """
@@ -27,7 +27,7 @@ def label(request, name_value):
         name = Name.objects.get(normalized_name=normalized_name)
 
         return http.HttpResponseRedirect(
-            reverse('name_entry_detail', args=[name.name_id]))
+            reverse('name:detail', args=[name.name_id]))
 
     except Name.DoesNotExist:
         return http.HttpResponseNotFound(
@@ -40,7 +40,7 @@ def label(request, name_value):
             .format(normalized_name))
 
 
-def entry_detail(request, name_id):
+def detail(request, name_id):
     """View for the Name detail page."""
     queryset = (
         Name.objects.select_related().
@@ -94,8 +94,8 @@ def opensearch(request):
     search_json_query = '{0}?q={{searchTerms}}'
 
     # Build the absolute URLs.
-    search_url = request.build_absolute_uri(reverse('name_search'))
-    search_json_url = request.build_absolute_uri(reverse('name_names'))
+    search_url = request.build_absolute_uri(reverse('name:search'))
+    search_json_url = request.build_absolute_uri(reverse('name:search-json'))
 
     # Compose the full URLs that will be sent to the template.
     search = search_query.format(search_url)

--- a/name/views.py
+++ b/name/views.py
@@ -128,7 +128,7 @@ def landing(request):
     return render(request, 'name/landing.html', counts)
 
 
-def map(request):
+def locations(request):
     """View for the Map page."""
     return render(request, 'name/map.html')
 

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -13,7 +13,7 @@ def test_feed_has_georss_namespace(rf):
     """Check that the georss namespace is present in the response
     content.
     """
-    request = rf.get(reverse('name_feed'))
+    request = rf.get(reverse('name:feed'))
     feed = NameAtomFeed()
     response = feed(request)
     assert 'xmlns:georss' in response.content
@@ -21,7 +21,7 @@ def test_feed_has_georss_namespace(rf):
 
 def test_feed_response_is_application_xml(rf):
     """Verify the Content-Type header is set to `application/xml`."""
-    request = rf.get(reverse('name_feed'))
+    request = rf.get(reverse('name:feed'))
     feed = NameAtomFeed()
     response = feed(request)
     assert response['Content-Type'] == 'application/xml'
@@ -34,7 +34,7 @@ def test_feed_item_with_location(rf):
     name = Name.objects.create(name="Test", name_type=Name.PERSONAL)
     name.location_set.create(latitude=33.210241, longitude=-97.148857)
 
-    request = rf.get(reverse('name_feed'))
+    request = rf.get(reverse('name:feed'))
     feed = NameAtomFeed()
     response = feed(request)
 
@@ -47,7 +47,7 @@ def test_feed_with_item_without_location(rf):
     """
     Name.objects.create(name="Test", name_type=Name.PERSONAL)
 
-    request = rf.get(reverse('name_feed'))
+    request = rf.get(reverse('name:feed'))
     feed = NameAtomFeed()
     response = feed(request)
 
@@ -61,7 +61,7 @@ def test_feed_item_without_location_has_georss_element(rf):
     name = Name.objects.create(name="Test", name_type=Name.PERSONAL)
     name.location_set.create(latitude=33.210241, longitude=-97.148857)
 
-    request = rf.get(reverse('name_feed'))
+    request = rf.get(reverse('name:feed'))
     feed = NameAtomFeed()
     response = feed(request)
 
@@ -75,7 +75,7 @@ def test_feed_item_without_location_does_not_have_georss_element(rf):
     """
     Name.objects.create(name="Test", name_type=Name.PERSONAL)
 
-    request = rf.get(reverse('name_feed'))
+    request = rf.get(reverse('name:feed'))
     feed = NameAtomFeed()
     response = feed(request)
 

--- a/tests/test_name_detail.py
+++ b/tests/test_name_detail.py
@@ -19,7 +19,7 @@ def test_person_itemprops(client):
     name = Name.objects.create(name='test person',
                                name_type=Name.PERSONAL, begin='2012-01-12')
     response = client.get(
-        reverse('name_entry_detail', args=[name.name_id]))
+        reverse('name:detail', args=[name.name_id]))
 
     assert 'itemprop=\"name\"' in response.content
     assert 'itemprop=\'url\'' in response.content
@@ -38,7 +38,7 @@ def test_building_itemprops(client):
     name = Name.objects.create(name='test building',
                                name_type=Name.BUILDING, begin='2000-01-12')
     response = client.get(
-        reverse('name_entry_detail', args=[name.name_id]))
+        reverse('name:detail', args=[name.name_id]))
 
     assert 'itemprop=\"name\"' in response.content
     assert 'itemprop=\'url\'' in response.content
@@ -57,7 +57,7 @@ def test_organization_itemprops(client):
     name = Name.objects.create(name='test organization', begin='2000-01-12',
                                name_type=Name.ORGANIZATION)
     response = client.get(
-        reverse('name_entry_detail', args=[name.name_id]))
+        reverse('name:detail', args=[name.name_id]))
 
     assert 'itemprop=\"name\"' in response.content
     assert 'itemprop=\'url\'' in response.content
@@ -76,7 +76,7 @@ def test_event_itemprops(client):
     name = Name.objects.create(name='test event',
                                name_type=Name.EVENT, begin='2500-01-12')
     response = client.get(
-        reverse('name_entry_detail', args=[name.name_id]))
+        reverse('name:detail', args=[name.name_id]))
 
     assert 'itemprop=\"name\"' in response.content
     assert 'itemprop=\'url\'' in response.content

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,7 +14,7 @@ def test_json_search_returns_expected_results(client, name_fixtures):
     and that the status code is 200.
     """
     query = query_template.format('Personal', 'person')
-    response = client.get(reverse('name_names') + query)
+    response = client.get(reverse('name:search-json') + query)
 
     assert response.status_code is 200
     assert json.loads(response.content)[0]['name'] == 'test person'
@@ -23,7 +23,7 @@ def test_json_search_returns_expected_results(client, name_fixtures):
 def test_json_search_with_multiple_name_types(client, name_fixtures):
     query = query_template.format('Personal,Organization', 'test')
     response = client.get(
-        reverse('name_names') + query)
+        reverse('name:search-json') + query)
     json_results = json.loads(response.content)
 
     assert response.status_code is 200
@@ -33,14 +33,14 @@ def test_json_search_with_multiple_name_types(client, name_fixtures):
 def test_can_search(client, name_fixtures):
     """Test the HTML search returns correctly."""
     query = query_template.format('Personal', 'test')
-    response = client.get(reverse('name_search') + query)
+    response = client.get(reverse('name:search') + query)
     assert response.status_code is 200
 
 
 def test_search_multiple_name_types(client, name_fixtures):
     query = query_template.format('Personal,Organization', 'test')
     response = client.get(
-        reverse('name_search') + query)
+        reverse('name:search') + query)
 
     assert response.status_code is 200
 
@@ -48,14 +48,14 @@ def test_search_multiple_name_types(client, name_fixtures):
 def test_search_with_q(client, twenty_name_fixtures):
     """Search with q only. No name_types provided."""
     name = twenty_name_fixtures.first()
-    url = reverse('name_search')
+    url = reverse('name:search')
     response = client.get(url, {'q': name.name})
     name_list = response.context[-1]['name_list']
     assert name in name_list
 
 
 def test_search_with_q_type(client, search_fixtures):
-    url = reverse('name_search')
+    url = reverse('name:search')
     response = client.get(url, {'q_type': 'Personal'})
     name_list = response.context[-1]['name_list']
     assert len(name_list) == 4
@@ -63,7 +63,7 @@ def test_search_with_q_type(client, search_fixtures):
 
 
 def test_search_with_two_q_types(client, search_fixtures):
-    url = reverse('name_search')
+    url = reverse('name:search')
     response = client.get(url, {'q_type': 'Personal,Event'})
     name_list = response.context[-1]['name_list']
     assert len(name_list) == 8
@@ -71,7 +71,7 @@ def test_search_with_two_q_types(client, search_fixtures):
 
 
 def test_search_without_query(client, search_fixtures):
-    url = reverse('name_search')
+    url = reverse('name:search')
     response = client.get(url)
     name_list = response.context[-1]['name_list']
     assert len(name_list) is 0

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -4,10 +4,10 @@ from django.template import Template, RequestContext
 
 
 @pytest.mark.parametrize('url_name,arg', [
-    ("name_label", "test-label"),
-    ("name_json", "nm000002"),
-    ("name_mads_serialize", "nm000002"),
-    ("name_entry_detail", "nm000002"),
+    ("name:label", "test-label"),
+    ("name:detail-json", "nm000002"),
+    ("name:mads-serialize", "nm000002"),
+    ("name:detail", "nm000002"),
 ])
 def test_absolute_url_with_argument(rf, url_name, arg):
     request = rf.get("/")
@@ -24,15 +24,15 @@ def test_absolute_url_with_argument(rf, url_name, arg):
 
 
 @pytest.mark.parametrize('url_name', [
-    'name_stats',
-    'name_feed',
-    'name_map',
-    'name_landing',
-    'name_export',
-    'name_search',
-    'name_names',
-    'name_about',
-    'name_opensearch',
+    'name:stats',
+    'name:feed',
+    'name:map',
+    'name:landing',
+    'name:export',
+    'name:search',
+    'name:search-json',
+    'name:about',
+    'name:opensearch',
 ])
 def test_absolute_url_without_argument(rf, url_name):
     request = rf.get("/")
@@ -54,9 +54,9 @@ def test_absolute_url_handles_empty_arguments(rf):
     template = '{{% load name_extras %}}{{% absolute_url "{name}" "" "" %}}'
 
     rendered = (
-        Template(template.format(name="name_landing"))
+        Template(template.format(name="name:landing"))
         .render(context)
     )
 
-    expected = request.build_absolute_uri(reverse("name_landing"))
+    expected = request.build_absolute_uri(reverse("name:landing"))
     assert expected, rendered

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db
 
 def test_entry_detail_returns_ok(client, name_fixture):
     response = client.get(
-        reverse('name_entry_detail', args=[name_fixture.name_id]))
+        reverse('name:detail', args=[name_fixture.name_id]))
     assert 200 == response.status_code
 
 
@@ -18,7 +18,7 @@ def test_entry_detail_returns_gone(client, name_fixture):
     name_fixture.record_status = 1
     name_fixture.save()
     response = client.get(
-        reverse('name_entry_detail', args=[name_fixture.name_id]))
+        reverse('name:detail', args=[name_fixture.name_id]))
     assert 410 == response.status_code
 
 
@@ -26,27 +26,27 @@ def test_entry_detail_returns_not_found(client, name_fixture):
     name_fixture.record_status = 2
     name_fixture.save()
     response = client.get(
-        reverse('name_entry_detail', args=[name_fixture.name_id]))
+        reverse('name:detail', args=[name_fixture.name_id]))
     assert 404 == response.status_code
 
 
 def test_merged_entry_detail_returns_ok(client, merged_name_fixtures):
     merged, primary = merged_name_fixtures
     response = client.get(
-        reverse('name_entry_detail', args=[primary.name_id]))
+        reverse('name:detail', args=[primary.name_id]))
     assert 200 == response.status_code
 
 
 def test_merged_entry_detail_returns_redirect(client, merged_name_fixtures):
     merged, primary = merged_name_fixtures
     response = client.get(
-        reverse('name_entry_detail', args=[merged.name_id]))
+        reverse('name:detail', args=[merged.name_id]))
     assert 302 == response.status_code
 
 
 def test_label_returns_redirected(client, name_fixture):
     response = client.get(
-        reverse('name_label', args=[name_fixture.name]))
+        reverse('name:label', args=[name_fixture.name]))
     assert 302 == response.status_code
 
 
@@ -57,7 +57,7 @@ def test_label_returns_not_found_without_query(client):
     code of 404.
     """
     response = client.get(
-        reverse('name_label', args=['']))
+        reverse('name:label', args=['']))
     assert 404 == response.status_code
     assert 'No matching term found' not in response.content
 
@@ -70,7 +70,7 @@ def test_label_returns_not_found_with_query(client):
     code of 404.
     """
     response = client.get(
-        reverse('name_label', args=['&&&&&&&&']))
+        reverse('name:label', args=['&&&&&&&&']))
     assert 404 == response.status_code
     assert 'No matching term found' in response.content
 
@@ -81,70 +81,70 @@ def test_label_returns_not_found_multiple_names_found(client):
     Name.objects.create(name=name_name, name_type=Name.PERSONAL)
 
     response = client.get(
-        reverse('name_label', args=[name_name]))
+        reverse('name:label', args=[name_name]))
     assert 404 == response.status_code
     assert 'There are multiple Name objects with' in response.content
 
 
 def test_export(client, name_fixture):
-    response = client.get(reverse('name_export'))
+    response = client.get(reverse('name:export'))
     assert 200 == response.status_code
 
 
 def test_opensearch(client):
-    response = client.get(reverse('name_opensearch'))
+    response = client.get(reverse('name:opensearch'))
     assert 200 == response.status_code
 
 
 def test_feed(client):
-    response = client.get(reverse('name_feed'))
+    response = client.get(reverse('name:feed'))
     assert 200 == response.status_code
 
 
 def test_about(client):
-    response = client.get(reverse('name_about'))
+    response = client.get(reverse('name:about'))
     assert 200 == response.status_code
 
 
 def test_stats_returns_ok(client, name_fixture):
-    response = client.get(reverse('name_stats'))
+    response = client.get(reverse('name:stats'))
     assert 200 == response.status_code
 
 
 def test_stats_returns_ok_with_no_names(client):
-    response = client.get(reverse('name_stats'))
+    response = client.get(reverse('name:stats'))
     assert 200 == response.status_code
 
 
 def test_get_names_returns_ok(client):
-    response = client.get(reverse('name_names'))
+    response = client.get(reverse('name:search-json'))
     assert 200 == response.status_code
 
 
 def test_get_names_xhr_returns_ok(client):
     response = client.get(
-        reverse('name_names'),
+        reverse('name:search-json'),
         HTTP_X_REQUESTED_WITH='XMLHttpRequest')
     assert 200 == response.status_code
 
 
 def test_get_names_xhr_returns_only_10_names(client, twenty_name_fixtures):
     response = client.get(
-        reverse('name_names'),
+        reverse('name:search-json'),
         HTTP_X_REQUESTED_WITH='XMLHttpRequest')
     names = json.loads(response.content)
     assert len(names) == 10
 
 
 def test_get_names_has_cors_headers(client):
-    response = client.get(reverse('name_names'))
+    response = client.get(reverse('name:search-json'))
     assert response.has_header('Access-Control-Allow-Origin')
     assert response.has_header('Access-Control-Allow-Headers')
     assert response['Access-Control-Allow-Origin'] == '*'
 
 
 def test_landing(client):
-    response = client.get(reverse('name_landing'))
+    response = client.get(reverse('name:landing'))
     assert 200 == response.status_code
 
 
@@ -154,7 +154,7 @@ def test_landing_does_not_count_inactive_names(client, status_name_fixtures):
     The status_name_fixture supplies this test with 3 Name objects of each
     Name type, where only one of each Name type is active.
     """
-    response = client.get(reverse('name_landing'))
+    response = client.get(reverse('name:landing'))
     context = response.context[-1]['counts']
     assert 1 == context['personal']
     assert 1 == context['building']
@@ -165,17 +165,17 @@ def test_landing_does_not_count_inactive_names(client, status_name_fixtures):
 
 
 def test_name_json_returns_ok(client, name_fixture):
-    response = client.get(reverse('name_json', args=[name_fixture]))
+    response = client.get(reverse('name:detail-json', args=[name_fixture]))
     assert 200 == response.status_code
 
 
 def test_name_json_handles_unknown_name(client):
-    response = client.get(reverse('name_json', args=[0]))
+    response = client.get(reverse('name:detail-json', args=[0]))
     assert 404 == response.status_code
 
 
 def test_map_returns_ok(client):
-    response = client.get(reverse('name_map'))
+    response = client.get(reverse('name:map'))
     assert 200 == response.status_code
 
 
@@ -189,7 +189,7 @@ def test_map_json_xhr_returns_payload(client):
         belong_to_name=name)
 
     response = client.get(
-        reverse('name_map_json'),
+        reverse('name:locations-json'),
         HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
     assert name.name_id in response.content
@@ -198,7 +198,7 @@ def test_map_json_xhr_returns_payload(client):
 
 def test_map_json_xhr_returns_with_no_locations(client, twenty_name_fixtures):
     response = client.get(
-        reverse('name_map_json'),
+        reverse('name:locations-json'),
         HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
     assert response.context is None
@@ -206,22 +206,22 @@ def test_map_json_xhr_returns_with_no_locations(client, twenty_name_fixtures):
 
 
 def test_map_json_returns_not_found(client, twenty_name_fixtures):
-    response = client.get(reverse('name_map_json'))
+    response = client.get(reverse('name:locations-json'))
     assert response.status_code == 404
 
 
 def test_stats_json_returns_ok_with_no_names(client):
-    response = client.get(reverse('name_stats_json'))
+    response = client.get(reverse('name:stats-json'))
     assert response.status_code == 200
 
 
 def test_stats_json_returns_ok(client, search_fixtures):
-    response = client.get(reverse('name_stats_json'))
+    response = client.get(reverse('name:stats-json'))
     assert response.status_code == 200
 
 
 def test_stats_json_json_data(client, search_fixtures):
-    response = client.get(reverse('name_stats_json'))
+    response = client.get(reverse('name:stats-json'))
     data = json.loads(response.content)
     assert data.get('created', False)
     assert data.get('modified', False)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -6,6 +6,6 @@ admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^name/', include(urls)),
+    url(r'^name/', include(urls, namespace='name')),
     url(r'^admin/', include(admin.site.urls))
 )


### PR DESCRIPTION
Closes #62 
Closes #78 
Closes #32 

This is mostly to add in namespaced urls, but I took care of #62 and #78 because they were related to the UrlConf. 

Notice that there is still one line in `name/urls.py` that exceeds 79 chars. I left this intentionally because it keeps the url declarations consistent.
