### PR TITLE
Update Env and Docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 FROM python:2.7
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app
-ENV TOXENV=py27-django{16,17,18}-{mysql,postgres},flake8,docs
 RUN apt-get update -qq && apt-get install -y python-mysqldb mysql-client
 RUN mkdir /app
 WORKDIR /app

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 include *.txt *.md
 recursive-include name/templates * 
 recursive-include name/static * 
+recursive-include name/fixtures *

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ docker-compose run --rm web tox
 ```
 The Tox configuration will test this app with Django 1.6 - 1.8.
 
-To run the tests only with the development environment (i.e. with Django 1.7)
+To run the tests only with the development environment (i.e. with Django 1.8)
 ```sh
 $ docker-compose run --rm web ./runtests.py
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Contributors:
 
 To take advantage of the dev environment that is already configured, you need to have Docker(>= 1.3) and Docker Compose installed.
 
-Install [Docker](https://docs.docker.com/installation/)
+Install [Docker](https://docs.docker.com)
 
 Install Docker Compose
 ```sh

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -10,7 +10,7 @@ To take advantage of the dev environment that is already configured, you need to
 
 Install Docker_
 
-.. _Docker: https://docs.docker.com/installation/
+.. _Docker: https://docs.docker.com
 
 Install Docker Compose.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -68,7 +68,7 @@ To run the tests via Tox, use this command.
 
 The Tox configuration will test this app with Django 1.6 - 1.8.
 
-To run the tests only with the development environment (i.e. with Django 1.7).
+To run the tests only with the development environment (i.e. with Django 1.8).
 
 .. code-block:: sh
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,6 +51,8 @@ Installation
             'APP_DIRS': True,
             'OPTIONS': {
                 'context_processors': [
+                    # ...
+                    'django.contrib.auth.context_processors.auth',
                     'django.template.context_processors.request',
                     'name.context_processors.name'
                 ],

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Packages that are only used in the dev environments.
-Django==1.7
-django-debug-toolbar==1.2.2
+Django==1.8
+django-debug-toolbar==1.3.2
 ipython==2.4.0
 mysql-python==1.2.5

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -42,6 +42,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
+                'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.request',
                 'name.context_processors.name'
             ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -138,7 +138,7 @@ class TestName:
         """Test that has_geocode returns True."""
 
         lat, lng = 33.210241, -97.148857
-        name = Name.objects.create(name="Test Name", name_type=Name.BUILDING)
+        name = Name.objects.create(name="Test Name", name_type=Name.PERSONAL)
         Location.objects.create(belong_to_name=name, longitude=lng,
                                 latitude=lat)
         assert name.has_geocode()
@@ -146,7 +146,7 @@ class TestName:
     @pytest.mark.django_db
     def test_does_not_have_geocode(self):
         """Test that has_geocode returns False."""
-        name = Name.objects.create(name="Test Name", name_type=Name.BUILDING)
+        name = Name.objects.create(name="Test Name", name_type=Name.PERSONAL)
         assert not name.has_geocode()
 
     def test_has_unicode_method(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ exclude = *migrations/*
 
 [tox]
 envlist =
-    py27-django{16,17,18,master}-{mysql,postgres},
+    py27-django{16,17,18}-{mysql,postgres},
     flake8,
     docs
 


### PR DESCRIPTION
Fixes #89 and fixes #88 

Takes care of a few things:
- A more sane way of determining which tox envs to use locally
- Upgrade the dev env to use Django 1.8
- Fix the links to the docker installation docs
- The fixtures file is now included in the distribution.
