### PR TITLE
Fix stats generation.

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -2,7 +2,7 @@
 tox==1.8.1
 
 # Pytest packages.
-pytest-django==2.8.0
+pytest-django==2.9.1
 pytest==2.6.4
 pytest-cov==1.8.1
 

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,7 @@ PYTEST_ARGS = {
     'fast': ['tests', '-q'],
 }
 
-FLAKE8_ARGS = ['name', 'tests', '--ignore=F403,E501']
+FLAKE8_ARGS = ['name', 'tests', '--ignore=F403,E501,F999']
 
 
 sys.path.append(os.path.dirname(__file__))

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ envlist =
 [testenv]
 passenv = DB_*
 deps =
-    django16: Django==1.6
-    django17: Django==1.7
-    django18: Django==1.8
+    django16: Django~=1.6.0
+    django17: Django~=1.7.0
+    django18: Django~=1.8.0
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     mysql: mysql-python
     postgres: psycopg2


### PR DESCRIPTION
Fixes #94 
### The Problem

Between the different versions of Django, and supporting Postgres and MySQL, the stats were just plain broken.
### The Fix

Uses a very simple SQL query, and leans on Python to group the results, instead of relying on SQL to report the results back in the desired format.
### But SQL can do this for us?!

The issue I ran into is that the ORM in 1.6-1.8 gives back inconsistent results when you do `GROUP BY YEAR(field), MONTH(field)` in ORM speak. Dropping down to raw SQL was also not an option because we would have to maintain two queries, one for Postgres, and one for MySQL :disappointed:

:rainbow: 
