### PR TITLE
Fix the export view so it doesn't return representations of byte strings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM python:3.7
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app
+ENV PYTHONDONTWRITEBYTECODE 1
 RUN apt-get update -qq && apt-get install -y python-mysqldb default-mysql-client
 RUN mkdir /app
 WORKDIR /app

--- a/name/views.py
+++ b/name/views.py
@@ -75,7 +75,7 @@ def export(request):
     for n in Name.objects.visible():
         writer.writerow([
             n.get_name_type_label().lower(),
-            n.name.encode('utf-8'),
+            n.name,
             request.build_absolute_uri(n.get_absolute_url())
         ])
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -88,6 +88,9 @@ def test_label_returns_not_found_multiple_names_found(client):
 
 def test_export(client, name_fixture):
     response = client.get(reverse('name:export'))
+    expected = 'personal\ttest person\thttp://testserver{}\r\n'.format(
+        name_fixture.get_absolute_url())
+    assert expected == response.content.decode()
     assert 200 == response.status_code
 
 


### PR DESCRIPTION
ping @ldko this is ready for review. Small fix for the small problem of the export view returning a tsv file that had python representations of byte strings rather than just the plain strings.