### PR TITLE
Fix urls

### DIFF
--- a/name/urls.py
+++ b/name/urls.py
@@ -24,5 +24,5 @@ urlpatterns = [
     path('stats/', views.stats, name='stats'),
     path('<slug:name_id>.json', api.name_json, name='detail-json'),
     path('<slug:name_id>.mads.xml', views.mads_serialize, name='mads-serialize'),
-    path('<slug:name_id>/', views.detail, name='detail')
+    path('<name_id>/', views.detail, name='detail')
 ]


### PR DESCRIPTION
@ldko @somexpert 

Replaced `slug` with `str` in url for `views.detail`. I have checked all django upgrades and found that here I have used `<slug>` when I am supposed to use `<str>`