### PR TITLE
Update markdown2 dependency; keep working in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /app
 ENV PYTHONDONTWRITEBYTECODE 1
 RUN apt-get update -qq && \
-    apt-get install -y  mariadb-server mariadb-client libmariadbclient-dev libssl-dev
+    apt-get install -y mariadb-server mariadb-client libmariadb-dev-compat libmariadb-dev libssl-dev
 RUN mkdir /app
 WORKDIR /app
 ADD requirements/ /app/requirements/

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,6 +1,6 @@
 # Packages that are required by the app.
 python-dateutil==2.7.3
-markdown2==2.4.0
+markdown2>=2.4.0
 djangorestframework==3.11.2
 
 git+https://github.com/unt-libraries/pynaco@master

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as fd:
 
 install_requires = [
     'python-dateutil==2.7.3',
-    'markdown2==2.4.0',
+    'markdown2>=2.4.0',
     'djangorestframework==3.11.2',
     'pynaco @ git+https://github.com/unt-libraries/pynaco',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ passenv = DB_*
 deps =
     django22: Django~=2.2.17
     mariadb: mysqlclient
-    postgres: psycopg2
+    postgres: psycopg2==2.8.6
     -rrequirements/requirements-test.txt
 commands =
     mariadb: ./runtests.py {posargs} --nolint --ds=tests.settings.test_mariadb


### PR DESCRIPTION
This PR is to satisfy a dependabot alert about markdown2 and (unrelated) make changes to keep the Docker build and Postgres tests working.

ping @gracieflores @somexpert please verify that you can run the app and tests per the README instructions